### PR TITLE
fix(deployment): Missed the command from compose file

### DIFF
--- a/generator/deployment.go
+++ b/generator/deployment.go
@@ -136,6 +136,7 @@ func (d *Deployment) AddContainer(service types.ServiceConfig) {
 		Resources: corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{},
 		},
+		Command: service.Command,
 	}
 	if _, ok := d.chart.Values[service.Name]; !ok {
 		d.chart.Values[service.Name] = NewValue(service, d.isMainApp)


### PR DESCRIPTION
This pull request enhances the handling and testing of container commands in the deployment generator. The changes include adding support for specifying commands in service configurations and introducing a new test to validate this functionality.

Enhancements to container command handling:

* [`generator/deployment.go`](diffhunk://#diff-d980d24f8bd990a1d2918af6dd78c2fff5bf931de30e8a81d1c5f800e78e1402R139): Updated the `AddContainer` method to include the `Command` field from the `service` configuration when creating containers.

Testing improvements:

* [`generator/deployment_test.go`](diffhunk://#diff-918af45463145df72129335ed9302dfd5fbebf1d99a79c40930051ff694291c8R498-R533): Added a new test, `TestCheckCommand`, to verify that commands specified in the service configuration are correctly included in the generated deployment YAML. The test ensures the command structure matches expectations and validates the number and content of command elements.Fixes #133