### PR TITLE
chore(make): manpage requirements are now in requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,7 +421,6 @@ manpage:
 		source venv/bin/activate && \
 		echo "==> Installing requirements in the virtual env..." && \
 		pip install -qq -r requirements.txt && \
-		pip install -qq -r manpage_requirements.txt && \
 		echo "==> Generating manpage..." && \
 		MANPAGE=true mkdocs build && \
 		rm -rf site &&


### PR DESCRIPTION
This pull request makes a small change to the `Makefile` by removing the installation step for `manpage_requirements.txt` during the virtual environment setup. This simplifies the process of generating the manpage.