### PR TITLE
fix(katenaryfile): Schema is broken without json annotation

### DIFF
--- a/generator/katenaryfile/main.go
+++ b/generator/katenaryfile/main.go
@@ -25,22 +25,22 @@ type StringOrMap any
 
 // Service is a struct that contains the service configuration for katenary
 type Service struct {
-	MainApp         *bool                          `yaml:"main-app,omitempty" jsonschema:"title=Is this service the main application"`
-	Values          []StringOrMap                  `yaml:"values,omitempty" jsonschema:"description=Environment variables to be set in values.yaml with or without a description"`
-	Secrets         *labelstructs.Secrets          `yaml:"secrets,omitempty" jsonschema:"title=Secrets,description=Environment variables to be set as secrets"`
-	Ports           *labelstructs.Ports            `yaml:"ports,omitempty" jsonschema:"title=Ports,description=Ports to be exposed in services"`
-	Ingress         *labelstructs.Ingress          `yaml:"ingress,omitempty" jsonschema:"title=Ingress,description=Ingress configuration"`
-	HealthCheck     *labelstructs.HealthCheck      `yaml:"health-check,omitempty" jsonschema:"title=Health Check,description=Health check configuration that respects the kubernetes api"`
-	SamePod         *string                        `yaml:"same-pod,omitempty" jsonschema:"title=Same Pod,description=Service that should be in the same pod"`
-	Description     *string                        `yaml:"description,omitempty" jsonschema:"title=Description,description=Description of the service that will be injected in the values.yaml file"`
-	Ignore          *bool                          `yaml:"ignore,omitempty" jsonschema:"title=Ignore,description=Ignore the service in the conversion"`
-	Dependencies    []labelstructs.Dependency      `yaml:"dependencies,omitempty" jsonschema:"title=Dependencies,description=Services that should be injected in the Chart.yaml file"`
-	ConfigMapFiles  *labelstructs.ConfigMapFiles   `yaml:"configmap-files,omitempty" jsonschema:"title=ConfigMap Files,description=Files that should be injected as ConfigMap"`
-	MapEnv          *labelstructs.MapEnv           `yaml:"map-env,omitempty" jsonschema:"title=Map Env,description=Map environment variables to another value"`
-	CronJob         *labelstructs.CronJob          `yaml:"cron-job,omitempty" jsonschema:"title=Cron Job,description=Cron Job configuration"`
-	EnvFrom         *labelstructs.EnvFrom          `yaml:"env-from,omitempty" jsonschema:"title=Env From,description=Inject environment variables from another service"`
-	ExchangeVolumes []*labelstructs.ExchangeVolume `yaml:"exchange-volumes,omitempty" jsonschema:"title=Exchange Volumes,description=Exchange volumes between services"`
-	ValuesFrom      *labelstructs.ValueFrom        `yaml:"values-from,omitempty" jsonschema:"title=Values From,description=Inject values from another service (secret or configmap environment variables)"`
+	MainApp         *bool                          `yaml:"main-app,omitempty" json:"main-app,omitempty" jsonschema:"title=Is this service the main application"`
+	Values          []StringOrMap                  `yaml:"values,omitempty" json:"values,omitempty" jsonschema:"description=Environment variables to be set in values.yaml with or without a description"`
+	Secrets         *labelstructs.Secrets          `yaml:"secrets,omitempty" json:"secrets,omitempty" jsonschema:"title=Secrets,description=Environment variables to be set as secrets"`
+	Ports           *labelstructs.Ports            `yaml:"ports,omitempty" json:"ports,omitempty" jsonschema:"title=Ports,description=Ports to be exposed in services"`
+	Ingress         *labelstructs.Ingress          `yaml:"ingress,omitempty" json:"ingress,omitempty" jsonschema:"title=Ingress,description=Ingress configuration"`
+	HealthCheck     *labelstructs.HealthCheck      `yaml:"health-check,omitempty" json:"health-check,omitempty" jsonschema:"title=Health Check,description=Health check configuration that respects the kubernetes api"`
+	SamePod         *string                        `yaml:"same-pod,omitempty" json:"same-pod,omitempty" jsonschema:"title=Same Pod,description=Service that should be in the same pod"`
+	Description     *string                        `yaml:"description,omitempty" json:"description,omitempty" jsonschema:"title=Description,description=Description of the service that will be injected in the values.yaml file"`
+	Ignore          *bool                          `yaml:"ignore,omitempty" json:"ignore,omitempty" jsonschema:"title=Ignore,description=Ignore the service in the conversion"`
+	Dependencies    []labelstructs.Dependency      `yaml:"dependencies,omitempty" json:"dependencies,omitempty" jsonschema:"title=Dependencies,description=Services that should be injected in the Chart.yaml file"`
+	ConfigMapFiles  *labelstructs.ConfigMapFiles   `yaml:"configmap-files,omitempty" json:"configmap-files,omitempty" jsonschema:"title=ConfigMap Files,description=Files that should be injected as ConfigMap"`
+	MapEnv          *labelstructs.MapEnv           `yaml:"map-env,omitempty" json:"map-env,omitempty" jsonschema:"title=Map Env,description=Map environment variables to another value"`
+	CronJob         *labelstructs.CronJob          `yaml:"cron-job,omitempty" json:"cron-job,omitempty" jsonschema:"title=Cron Job,description=Cron Job configuration"`
+	EnvFrom         *labelstructs.EnvFrom          `yaml:"env-from,omitempty" json:"env-from,omitempty" jsonschema:"title=Env From,description=Inject environment variables from another service"`
+	ExchangeVolumes []*labelstructs.ExchangeVolume `yaml:"exchange-volumes,omitempty" json:"exchange-volumes,omitempty" jsonschema:"title=Exchange Volumes,description=Exchange volumes between services"`
+	ValuesFrom      *labelstructs.ValueFrom        `yaml:"values-from,omitempty" json:"values-from,omitempty" jsonschema:"title=Values From,description=Inject values from another service (secret or configmap environment variables)"`
 }
 
 // OverrideWithConfig overrides the project with the katenary.yaml file. It

--- a/katenary.json
+++ b/katenary.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$defs": {
-    "ConfigMapFile": {
+    "ConfigMapFiles": {
       "items": {
         "type": "string"
       },
@@ -318,7 +318,7 @@
           "description": "Services that should be injected in the Chart.yaml file"
         },
         "configmap-files": {
-          "$ref": "#/$defs/ConfigMapFile",
+          "$ref": "#/$defs/ConfigMapFiles",
           "title": "ConfigMap Files",
           "description": "Files that should be injected as ConfigMap"
         },


### PR DESCRIPTION
We need to add json annotation. The yaml annoation is not enought when generating the schema.

See #144 