### PR TITLE
Features/oci image

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -5,9 +5,6 @@ on:
     types:
       - published
 
-  push:
-    branches:
-      - "features/**"
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -36,3 +33,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{github.ref_name}}

--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -1,0 +1,38 @@
+name: Build OCI image
+
+on:
+  release:
+    types:
+      - published
+
+  push:
+    branches:
+      - "features/**"
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./oci/katenary/Containerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__
 # local binaries
 katenary
 !cmd/katenary
+!oci/katenary

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ services:
     database:
         image: mariadb:10
         env_file:
-            # this valuse will be added in a configMap
+            # this values will be added in a configMap
             - my_env.env
         environment:
             MARIADB_USER: foo

--- a/doc/docs/.markdownlint.yaml
+++ b/doc/docs/.markdownlint.yaml
@@ -4,3 +4,6 @@ MD022: false
 MD033: false
 MD041: false
 MD046: false
+# list indentation
+MD007:
+  indent: 4

--- a/doc/docs/dependencies.md
+++ b/doc/docs/dependencies.md
@@ -3,14 +3,14 @@
 Katenary uses `compose-go` and several Kubernetes official packages.
 
 - `github.com/compose-spec/compose-go`: to parse compose files. It ensures :
-  - that the project respects the "compose" specification
-  - that Katenary uses the "compose" struct exactly the same way `podman compose` or `docker copose` does
+    - that the project respects the "compose" specification
+    - that Katenary uses the "compose" struct exactly the same way `podman compose` or `docker compose` does
 - `github.com/spf13/cobra`: to parse command line arguments, sub-commands and flags. It also generates completion for
   bash, zsh, fish and PowerShell.
 - `github.com/thediveo/netdb`: to get the standard names of a service from its port number
 - `gopkg.in/yaml.v3`:
-  - to generate `Chart.yaml` and `values.yaml` files (only)
-  - to parse Katenary labels in the compose file
+    - to generate `Chart.yaml` and `values.yaml` files (only)
+    - to parse Katenary labels in the compose file
 - `k8s.io/api` and `k8s.io/apimachinery` to create Kubernetes objects
 - `sigs.k8s.io/yaml`: to generate Katenary YAML files in the format of Kubernetes objects
 

--- a/oci/katenary/Containerfile
+++ b/oci/katenary/Containerfile
@@ -1,0 +1,15 @@
+ARG GOVERSION=1.24
+
+FROM docker.io/golang:${GOVERSION} AS builder
+ARG VERSION=master
+RUN set -xe; \
+  CGO_ENABLED=0 go install -v github.com/katenary/katenary/cmd/katenary@$VERSION;
+
+FROM scratch
+LABEL org.opencontainers.image.source=https://github.com/katenary/katenary
+LABEL org.opencontainers.image.description="Katenary converts compose files to Helm Chart"
+LABEL org.opencontainers.image.licenses=MIT
+COPY --from=builder /go/bin/katenary /usr/local/bin/katenary
+VOLUME /project
+WORKDIR /project
+ENTRYPOINT ["/usr/local/bin/katenary"]


### PR DESCRIPTION
This pull request introduces a new workflow for building and publishing OCI images, updates documentation and configuration files, and fixes minor typos and formatting issues. Below is a breakdown of the most important changes:

### New Workflow for OCI Image Building:
* Added a GitHub Actions workflow (`.github/workflows/build-oci.yaml`) to build and push OCI images on release events. This includes steps for repository checkout, container registry login, QEMU setup, Docker Buildx setup, and building/pushing the image.

see #153 

### Containerfile for OCI Image:
* Introduced a new `Containerfile` (`oci/katenary/Containerfile`) to build the `katenary` binary using Go and package it into a minimal container image. The image includes metadata labels and sets up `/project` as the working directory.

### Documentation Updates:
* Fixed a typo in `dependencies.md` by correcting "docker copose" to "docker compose."
* Corrected a comment typo in `README.md` by changing "this valuse" to "this values."

### Configuration Enhancements:
* Updated `.markdownlint.yaml` to add a rule for list indentation (`MD007`) with an indent level of 4.