### PR TITLE
Features/buildah build

### DIFF
--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -24,8 +24,8 @@ jobs:
         run: |-
           if ! comamnd -v buildah 2>/dev/null; then
             echo "Install Buildah"
-            apt-get update
-            apt-get install -y buildah
+            sudo apt-get update
+            sudo apt-get install -y buildah
           else
             echo "Buildah already installed"
           fi

--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -1,37 +1,43 @@
-name: Build OCI image
+name: Build and push OCI image
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - "**"
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  VERSION: ${{ github.ref_name }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./oci/katenary/Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{github.ref_name}}
+
+      - name: Install Buildah
+        run: |-
+          if ! comamnd -v buildah 2>/dev/null; then
+            echo "Install Buildah"
+            apt-get update
+            apt-get install -y buildah
+          else
+            echo "Buildah already installed"
+          fi
+
+      - name: Build and tag
+        run: |-
+          buildah build --build-arg VERSION=$VERSION -t katenary -f ./oci/katenary/Containerfile .
+          buildah tag katenary $REGISTRY/${IMAGE_NAME,,}:$VERSION
+          buildah tag katenary $REGISTRY/${IMAGE_NAME,,}:latest
+
+      - name: Push image
+        run: |-
+          buildah login $REGISTRY -u ${{ github.actor }} -p ${{ secret.GITHUB_TOKEN }}
+          buildah push $REGISTRY/${IMAGE_NAME,,}:$VERSION
+          buildah push $REGISTRY/${IMAGE_NAME,,}:latest

--- a/.github/workflows/build-oci.yaml
+++ b/.github/workflows/build-oci.yaml
@@ -38,6 +38,6 @@ jobs:
 
       - name: Push image
         run: |-
-          buildah login $REGISTRY -u ${{ github.actor }} -p ${{ secret.GITHUB_TOKEN }}
+          buildah login $REGISTRY -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
           buildah push $REGISTRY/${IMAGE_NAME,,}:$VERSION
           buildah push $REGISTRY/${IMAGE_NAME,,}:latest

--- a/oci/katenary/Containerfile
+++ b/oci/katenary/Containerfile
@@ -1,15 +1,17 @@
 ARG GOVERSION=1.24
 
 FROM docker.io/golang:${GOVERSION} AS builder
+WORKDIR /go/src/github.com/katenary/katenary
+COPY . .
 ARG VERSION=master
 RUN set -xe; \
-  CGO_ENABLED=0 go install -v github.com/katenary/katenary/cmd/katenary@$VERSION;
+  CGO_ENABLED=0 go build -ldflags="-X 'github.com/katenary/katenary/internal/generator.Version=$VERSION'" -trimpath -o katenary ./cmd/katenary
 
 FROM scratch
 LABEL org.opencontainers.image.source=https://github.com/katenary/katenary
 LABEL org.opencontainers.image.description="Katenary converts compose files to Helm Chart"
 LABEL org.opencontainers.image.licenses=MIT
-COPY --from=builder /go/bin/katenary /usr/local/bin/katenary
+COPY --from=builder /go/src/github.com/katenary/katenary/katenary /katenary
 VOLUME /project
 WORKDIR /project
-ENTRYPOINT ["/usr/local/bin/katenary"]
+ENTRYPOINT ["/katenary"]


### PR DESCRIPTION
This pull request updates the OCI image build process for the project, switching from Docker-based GitHub Actions to using Buildah for building and pushing images, and improves version tagging and binary embedding in the resulting image. The changes ensure that images are tagged with the correct version and latest tags, and the built binary now includes version information.

**Build workflow updates:**

* The `.github/workflows/build-oci.yaml` workflow now uses Buildah instead of Docker Buildx to build and push OCI images, and triggers on all tag pushes instead of releases. It also sets up the necessary permissions for package publishing and adds explicit version tagging for the images.

**Containerfile improvements:**

* The `oci/katenary/Containerfile` now builds the binary with embedded version information using Go linker flags, sets the working directory explicitly, and updates the image to copy the binary to `/katenary` with the entrypoint set accordingly.